### PR TITLE
Add Server GET endpoint to retrieve all employees

### DIFF
--- a/api/routes/employees.js
+++ b/api/routes/employees.js
@@ -16,6 +16,43 @@ const router = express.Router();
 // @access  Public
 router.get('/test', (req, res) => res.json({ msg: 'Employee Routes Work' }));
 
+router.get('/all', (req, res) => {
+  // if no token exists, send back unauthorized message
+  if (!req.headers.authorization) {
+    return res.status(401).json({ msg: 'You are not authorized to do this.' });
+  }
+
+  try {
+    // pull the role and the restaurant off the token
+    const { role, restaurant } = jwt.verify(req.headers.authorization.slice(7), keys.secretOrKey);
+
+    // if the logged in user isn't an admin or manager, they're not authed
+    if (!role.admin && !role.manager) {
+      return res.status(401).json({ msg: 'You are not authorized to do this.' });
+    }
+
+    // search query will filter by restaurant by default
+    const searchQuery = { restaurant };
+
+    // if the user is a manager, they will only see servers.
+    // admins can see all employees
+    if (role.manager) {
+      searchQuery.role = { admin: false, manager: false };
+    }
+
+    // find tall employees based on searchQuery
+    Employee.find(searchQuery)
+      .then(employees => {
+        res.status(200).json({ employees });
+      })
+      .catch(err => {
+        res.status(500).json({ err, msg: 'There was an error retrieving the servers.' });
+      });
+  } catch (err) {
+    res.status(400).json({ err, msg: 'There was an error verifying the token.' });
+  }
+});
+
 // @route   POST api/employees/admin/register
 // @desc    Adds an administrator to the DB
 // @access  Public

--- a/api/routes/employees.js
+++ b/api/routes/employees.js
@@ -36,7 +36,7 @@ router.get('/all', (req, res) => {
 
     // if the user is a manager, they will only see servers.
     // admins can see all employees
-    if (role.manager) {
+    if (role.manager && !role.admin) {
       searchQuery.role = { admin: false, manager: false };
     }
 


### PR DESCRIPTION
# Description

Managers and admins can now retrieve all employees by making a GET request to `/api/employees/all`. Admins can retrieve all employees, Managers can see only servers

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested with Postman

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
